### PR TITLE
Bump guava from 18.0 to 30.1.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <java.version>1.8</java.version>
-    <guava.version>18.0</guava.version>
+    <guava.version>30.1.1-jre</guava.version>
     <junit.version>4.13.1</junit.version>
   </properties>
 


### PR DESCRIPTION
Bumps the version of guava from 18.0 to 30.1.1-jre to address https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415 

Builds and runs as expected
```
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.153 s
[INFO] Finished at: 2021-05-11T16:40:03-04:00
[INFO] ------------------------------------------------------------------------
~/stripe/java-interview-prep master*
❯ java -jar target/sample-HEAD-SNAPSHOT.jar
Hello world!

```